### PR TITLE
feat: redesign results footer

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -77,6 +77,98 @@ body {
   overflow: auto;
 }
 
+.results-panel {
+  background: #050505;
+  border-top: 1px solid rgb(255 255 255 / 0.08);
+  margin-top: 32px;
+  padding: 20px;
+}
+
+.results-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.results-body {
+  margin-top: 12px;
+}
+
+.results-empty {
+  color: #9ca3af;
+  font-size: 0.9rem;
+}
+
+.results-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.results-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  border: 1px solid #1f2937;
+  border-radius: 12px;
+  padding: 12px 16px;
+  background: #0b0b0b;
+}
+
+.result-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.result-name {
+  font-weight: 600;
+  margin: 0;
+  color: #e5e7eb;
+  max-width: 420px;
+  word-break: break-word;
+}
+
+.result-meta {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin: 0;
+  color: #9ca3af;
+  font-size: 0.85rem;
+}
+
+.badge {
+  background: rgb(59 130 246 / 0.2);
+  color: #93c5fd;
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 0.75rem;
+}
+
+.result-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 600px) {
+  .results-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .result-actions {
+    width: 100%;
+  }
+}
+
+
 /* Helper text */
 .hint {
   color: #666;

--- a/app/static/js/upload.js
+++ b/app/static/js/upload.js
@@ -1,7 +1,9 @@
 const dropzone = document.getElementById('dropzone')
 const fileInput = document.getElementById('file-input')
 const uploadBtn = document.getElementById('upload-btn')
-// const resultEl = document.getElementById('result')
+const resultsList = document.getElementById('results-list')
+const resultsEmpty = document.getElementById('results-empty')
+const resultsStatus = document.getElementById('results-status')
 
 const pasteForm = document.getElementById('paste-form')
 const pasteContent = document.getElementById('paste-content')
@@ -14,17 +16,83 @@ const cancelTextBtn = document.getElementById('cancel-text-btn')
 
 let pendingFiles = []
 let inTextMode = false
+const MAX_RESULTS = 5
 
 // ---------- UI helpers ----------
 function setResult (obj) {
-  console.log(JSON.stringify(obj, null, 2))
-  // if (!resultEl) return;
-  // resultEl.textContent =
-  //  typeof obj === 'string' ? obj : JSON.stringify(obj, null, 2)
+  const message = typeof obj === 'string' ? obj : JSON.stringify(obj, null, 2)
+  console.log(message)
+  if (resultsStatus) resultsStatus.textContent = message
 }
 
 function setDragover (isOver) {
   dropzone.classList.toggle('dragover', isOver)
+}
+
+function formatBytes (bytes) {
+  if (!Number.isFinite(bytes)) return ''
+  if (bytes < 1024) return `${bytes} B`
+  const units = ['KB', 'MB', 'GB', 'TB']
+  let size = bytes
+  let unit = 'KB'
+  for (const label of units) {
+    size /= 1024
+    unit = label
+    if (size < 1024) break
+  }
+  return `${size.toFixed(1)} ${unit}`
+}
+
+function renderResultsRow (entry) {
+  if (!resultsList) return
+
+  const item = document.createElement('li')
+  item.className = 'results-row'
+
+  const details = document.createElement('div')
+  details.className = 'result-details'
+  const name = document.createElement('p')
+  name.className = 'result-name'
+  name.textContent = entry.original_name || entry.id
+  const meta = document.createElement('p')
+  meta.className = 'result-meta'
+
+  const type = document.createElement('span')
+  type.className = 'badge'
+  type.textContent = entry.content_type || 'unknown'
+  const size = document.createElement('span')
+  size.textContent = formatBytes(entry.bytes)
+  const id = document.createElement('span')
+  id.textContent = entry.id
+
+  meta.append(type, size, id)
+  details.append(name, meta)
+
+  const actions = document.createElement('div')
+  actions.className = 'result-actions'
+  if (entry.view_url) {
+    const view = document.createElement('a')
+    view.href = entry.view_url
+    view.target = '_blank'
+    view.rel = 'noopener'
+    view.className = 'btn-link'
+    view.textContent = 'View'
+    actions.append(view)
+  }
+  if (entry.download_url) {
+    const dl = document.createElement('a')
+    dl.href = entry.download_url
+    dl.className = 'btn-link secondary'
+    dl.textContent = 'Download'
+    actions.append(dl)
+  }
+
+  item.append(details, actions)
+  resultsList.prepend(item)
+
+  while (resultsList.children.length > MAX_RESULTS) {
+    resultsList.removeChild(resultsList.lastElementChild)
+  }
 }
 
 function enterTextMode (opts) {
@@ -75,12 +143,16 @@ async function postForm (url, form) {
 }
 
 function renderSavedLinks (data) {
-  if (data?.saved?.length) {
-    const lines = data.saved.map((s) => `${s.original_name} -> ${s.view_url}`)
-    setResult(lines.join('\n'))
-    return true
-  }
-  return false
+  const saved = Array.isArray(data?.saved) ? data.saved : []
+  if (!saved.length || !resultsList) return false
+
+  if (resultsEmpty) resultsEmpty.hidden = true
+  resultsList.hidden = false
+  saved.forEach((entry) => renderResultsRow(entry))
+
+  const label = saved.length === 1 ? `Saved ${saved[0].original_name || saved[0].id}` : `Saved ${saved.length} files`
+  setResult(label)
+  return true
 }
 
 // ---------- File queue helpers ----------

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -46,10 +46,18 @@
       });
     </script>
     {% endblock %} {% block content %}{% endblock %} {% block footer %}
-    <footer>
-      <h3>Results</h3>
-      <pre id="result" class="result">No uploads yet.</pre>
-      <p>Status: Ready</p>
+    <footer id="results" class="results-panel">
+      <div class="results-header">
+        <div>
+          <h3>Results</h3>
+          <p class="muted">Latest uploads this session</p>
+        </div>
+        <p id="results-status" class="sr-only" aria-live="polite">Ready</p>
+      </div>
+      <div class="results-body">
+        <div id="results-empty" class="results-empty">No uploads yet.</div>
+        <ul id="results-list" class="results-list" hidden></ul>
+      </div>
     </footer>
     {% endblock %}
   </body>


### PR DESCRIPTION
## Summary
- replace the plain `<pre>` footer with a structured Results panel that has an empty state, a live status label, and room for recent uploads
- rework `upload.js` so successful uploads render MIME type, size, and view/download links (capped list) instead of logging text blobs
- add the matching CSS for the new panel/badges so it fits the dark layout

## Testing
- `.venv/bin/ruff check`
- `timeout 5s .venv/bin/uvicorn app.main:app --host 127.0.0.1 --port 8000`
